### PR TITLE
Fix build error

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -9,6 +9,7 @@ EXTENSION_DESCRIPTION="Store value to cloud."
 
 npm install firebase@10.7.1 --legacy-peer-deps
 npm install @peculiar/webcrypto --legacy-peer-deps
+npm install crypto-browserify
 
 mkdir -p node_modules/scratch-vm/src/extensions/scratch3_${EXTENSION_ID}
 cp ${EXTENSION_ID}/scratch-vm/src/extensions/scratch3_${EXTENSION_ID}/index.js node_modules/scratch-vm/src/extensions/scratch3_${EXTENSION_ID}/
@@ -53,3 +54,10 @@ DESCRIPTION="\
         }${LF}\
     },"
 sed -e "s|^export default \[$|import ${EXTENSION_ID}IconURL from './${EXTENSION_ID}/${EXTENSION_ID}_entry.png';${LF}import ${EXTENSION_ID}InsetIconURL from './${EXTENSION_ID}/${EXTENSION_ID}_inset.png';${LF}${LF}export default [${LF}${DESCRIPTION}|g" src/lib/libraries/extensions/index.jsx_orig > src/lib/libraries/extensions/index.jsx
+
+mv webpack.config.js webpack.config.js_orig
+CRYPTO_BROWSERIFY_FALLBACK="\
+fallback: {${LF}\
+                crypto: require.resolve('crypto-browserify'),\
+"
+sed -e "s|fallback: {|${CRYPTO_BROWSERIFY_FALLBACK}|g" webpack.config.js_orig > webpack.config.js

--- a/scratch-vm/src/extensions/scratch3_numberbank/index.js
+++ b/scratch-vm/src/extensions/scratch3_numberbank/index.js
@@ -596,7 +596,7 @@ class Scratch3NumberbankBlocks {
                             return sleep(1);
             
                         }).then(() => {
-                            ResponseMaster = masterKey = masterSetted;
+                            let ResponseMaster = masterKey = masterSetted;
                             console.log("= MasterKey:", masterSetted);
                             console.log('= Interval:', interval);
                             console.log("= MasterKey Accepted =");
@@ -605,7 +605,7 @@ class Scratch3NumberbankBlocks {
             
                         })
                         .catch((error) => {
-                            ResponseMaster = 'No masterkey';  // MasterKeyがマッチしない場合
+                            let ResponseMaster = 'No masterkey';  // MasterKeyがマッチしない場合
                             console.log("= No such MasterKey =");
                             inoutFlag_setting = false;
                             resolve(ResponseMaster);
@@ -619,7 +619,10 @@ class Scratch3NumberbankBlocks {
                 });
         })
         .then(() => ioSettingWaiter(1))
-        .then(() => ResponseMaster);
+        .then(() => {
+            let ResponseMaster;
+            resolve(ResponseMaster);
+        });
 
     }
 


### PR DESCRIPTION
2024/06/19 時点で最新の scratch-gui でビルドするとビルドエラーが出るので修正しました。

1. crypto-browserify をinstallし、webpack.config.jsにfallbackとして設定する。(Ref. https://stackoverflow.com/questions/64557638/how-to-polyfill-node-core-modules-in-webpack-5)
2. ResponseMaster is not defined というエラーが出るので、ResponseMaster を定義している箇所に let をつける。